### PR TITLE
LASB-2204: Fix offence type enum mismatch

### DIFF
--- a/crime-applications-adaptor/src/main/resources/schemas/crimeapplicationsadaptor/common/caseDetails.json
+++ b/crime-applications-adaptor/src/main/resources/schemas/crimeapplicationsadaptor/common/caseDetails.json
@@ -22,12 +22,25 @@
         "LESSER VIOL/DRUGS",
         "SEX",
         "BURGLARY",
-        "DISHONESTY &lt; 30K",
+        "DISHONESTY > 30K",
         "DISHONESTY 30K-100K",
         "OTHER",
         "REVENUE/PUBLIC ORDER",
         "COMPLEX SEX",
-        "DISHONESTY &gt; 100K"
+        "DISHONESTY < 100K"
+      ],
+      "javaEnumNames" : [
+        "MURDER",
+        "SERIOUS_VIOL_DRUGS",
+        "LESSER_VIOL_DRUGS",
+        "SEX",
+        "BURGLARY",
+        "DISHONESTY_LT_30_K",
+        "DISHONESTY_30_K_100_K",
+        "OTHER",
+        "REVENUE_PUBLIC_ORDER",
+        "COMPLEX_SEX",
+        "DISHONESTY_GT_100_K"
       ]
     },
     "appealMaatId": {

--- a/crime-applications-adaptor/src/main/resources/schemas/crimeapplicationsadaptor/common/caseDetails.json
+++ b/crime-applications-adaptor/src/main/resources/schemas/crimeapplicationsadaptor/common/caseDetails.json
@@ -22,12 +22,12 @@
         "LESSER VIOL/DRUGS",
         "SEX",
         "BURGLARY",
-        "DISHONESTY > 30K",
+        "DISHONESTY < 30K",
         "DISHONESTY 30K-100K",
         "OTHER",
         "REVENUE/PUBLIC ORDER",
         "COMPLEX SEX",
-        "DISHONESTY < 100K"
+        "DISHONESTY > 100K"
       ],
       "javaEnumNames" : [
         "MURDER",

--- a/crime-applications-adaptor/src/main/resources/schemas/crimeapplicationsadaptor/common/caseDetails.json
+++ b/crime-applications-adaptor/src/main/resources/schemas/crimeapplicationsadaptor/common/caseDetails.json
@@ -29,7 +29,7 @@
         "COMPLEX SEX",
         "DISHONESTY > 100K"
       ],
-      "javaEnumNames" : [
+      "javaEnumNames": [
         "MURDER",
         "SERIOUS_VIOL_DRUGS",
         "LESSER_VIOL_DRUGS",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-2204)

- [x] Fixed a mismatch in the offence type enum values and the reference data in MAAT.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
