### PR TITLE
LASB-3581

### DIFF
--- a/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CaseDetailsMapper.java
+++ b/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CaseDetailsMapper.java
@@ -22,7 +22,7 @@ class CaseDetailsMapper {
     caseDetails.setOffenceClass(offenceClassMapper.map(crimeApplyCaseDetails.getOffenceClass()));
     caseDetails.setAppealMaatId(crimeApplyCaseDetails.getAppealMaatId());
     caseDetails.setAppealWithChangesDetails(crimeApplyCaseDetails.getAppealWithChangesDetails());
-    caseDetails.setAppealReceivedDate(crimeApplyCaseDetails.getAppealLodgedDate());
+    // LASB-3851 Do not map the appealReceivedDate as this will not be persisted correctly in MAAT
 
     return caseDetails;
   }

--- a/crime-applications-adaptor/application/src/test/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CaseDetailsMapperTest.java
+++ b/crime-applications-adaptor/application/src/test/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CaseDetailsMapperTest.java
@@ -27,7 +27,7 @@ class CaseDetailsMapperTest {
 
     String actualCaseDetailsJSON = JsonUtils.objectToJson(actualCaseDetails);
     JSONAssert.assertEquals(
-        "{\"caseType\":\"APPEAL CC\",\"offenceClass\":\"MURDER\",\"appealReceivedDate\":\"2021-10-25\"}",
+        "{\"caseType\":\"APPEAL CC\",\"offenceClass\":\"MURDER\"}",
         actualCaseDetailsJSON,
         JSONCompareMode.STRICT);
   }

--- a/crime-applications-adaptor/application/src/test/resources/data/crimeapplicationsadaptor/CrimeApplication_employed.json
+++ b/crime-applications-adaptor/application/src/test/resources/data/crimeapplicationsadaptor/CrimeApplication_employed.json
@@ -4,8 +4,7 @@
   "applicationType": "initial",
   "caseDetails": {
     "caseType": "APPEAL CC",
-    "offenceClass": "MURDER",
-    "appealReceivedDate": "2021-10-25"
+    "offenceClass": "MURDER"
   },
   "magsCourt": {
     "court": "Cardiff Magistrates' Court"

--- a/crime-applications-adaptor/application/src/test/resources/data/crimeapplicationsadaptor/CrimeApplication_partnerDetails.json
+++ b/crime-applications-adaptor/application/src/test/resources/data/crimeapplicationsadaptor/CrimeApplication_partnerDetails.json
@@ -4,8 +4,7 @@
   "applicationType": "initial",
   "caseDetails": {
     "caseType": "APPEAL CC",
-    "offenceClass": "MURDER",
-    "appealReceivedDate": "2021-10-25"
+    "offenceClass": "MURDER"
   },
   "magsCourt": {
     "court": "Cardiff Magistrates' Court"

--- a/crime-applications-adaptor/application/src/test/resources/data/crimeapplicationsadaptor/CrimeApplication_unemployed.json
+++ b/crime-applications-adaptor/application/src/test/resources/data/crimeapplicationsadaptor/CrimeApplication_unemployed.json
@@ -4,8 +4,7 @@
   "applicationType": "initial",
   "caseDetails": {
     "caseType": "APPEAL CC",
-    "offenceClass": "MURDER",
-    "appealReceivedDate": "2021-10-25"
+    "offenceClass": "MURDER"
   },
   "magsCourt": {
     "court": "Cardiff Magistrates' Court"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3581)

The `appealReceivedDate` is not persisted in MAAT following injection and is therefore causing data processing issues. Once a long term solution for this has been agreed this mapping logic can be restored.

This will mean case workers have to manually enter the date for the time being, whilst still allowing appeal cases to be injected, which is something that was not possible with eForms.

