### PR TITLE
LASB-3900 [CAA & MAAT API] Adding field meansReviewType & passportReviewType of the means_test to the API result

### DIFF
--- a/crime-applications-adaptor/application/build.gradle
+++ b/crime-applications-adaptor/application/build.gradle
@@ -24,7 +24,7 @@ def versions = [
         resilience4jVersion    : "2.2.0",
         commonsioVersion       : '2.11.0',
         sentryVersion          : "7.11.0",
-        commonsVersion         : "1.7.1",
+        commonsVersion         : "1.9.0",
         tomcatEmbedCoreVersion : "10.1.34",
 ]
 

--- a/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapper.java
+++ b/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapper.java
@@ -52,6 +52,7 @@ public class CrimeApplicationResultMapper {
             : repOrderState.getMeansInitResult());
     crimeApplicationResult.setDateMeansCreated(repOrderState.getDateMeansCreated());
     crimeApplicationResult.setMeansAssessorName(repOrderState.getMeansAssessorName());
+    crimeApplicationResult.setMeansReviewType(repOrderState.getMeansReviewType());
   }
 
   private void mapPassportAssessments(
@@ -61,6 +62,7 @@ public class CrimeApplicationResultMapper {
           mapPassportResults(repOrderState.getPassportResult()));
       crimeApplicationResult.setDatePassportCreated(repOrderState.getDatePassportCreated());
       crimeApplicationResult.setPassportAssessorName(repOrderState.getPassportAssessorName());
+      crimeApplicationResult.setPassportReviewType(repOrderState.getPassportReviewType());
     }
   }
 

--- a/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/model/RepOrderState.java
+++ b/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/model/RepOrderState.java
@@ -43,4 +43,7 @@ public class RepOrderState {
 
   private String fundingDecision;
   private String ccRepDecision;
+
+  private String meansReviewType;
+  private String passportReviewType;
 }

--- a/crime-applications-adaptor/application/src/test/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapperTest.java
+++ b/crime-applications-adaptor/application/src/test/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapperTest.java
@@ -124,6 +124,8 @@ class CrimeApplicationResultMapperTest {
         .iojAppealAssessorName("IOJ APPEAL ASSESSOR")
         .iojAppealDate(LocalDate.of(2024, 5, 5).atStartOfDay())
         .ccRepDecision("Granted - Passed Means Test")
+        .meansReviewType("NAFI")
+        .passportReviewType("ER")
         .build();
   }
 
@@ -149,6 +151,8 @@ class CrimeApplicationResultMapperTest {
     result.setIojAppealAssessorName("IOJ APPEAL ASSESSOR");
     result.setIojAppealDate(LocalDate.of(2024, 5, 5).atStartOfDay());
     result.setCcRepDecision("Granted - Passed Means Test");
+    result.setMeansReviewType("NAFI");
+    result.setPassportReviewType("ER");
     return result;
   }
 
@@ -173,6 +177,8 @@ class CrimeApplicationResultMapperTest {
         .iojAppealAssessorName(null)
         .iojAppealDate(null)
         .ccRepDecision(null)
+        .meansReviewType(null)
+        .passportReviewType(null)
         .build();
   }
 
@@ -195,6 +201,8 @@ class CrimeApplicationResultMapperTest {
     result.setIojAppealAssessorName(null);
     result.setIojAppealDate(null);
     result.setCcRepDecision(null);
+    result.setPassportReviewType(null);
+    result.setMeansReviewType(null);
     return result;
   }
 }


### PR DESCRIPTION


## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3900)

Describe what you did and why.

As part of the enhancement to the LAA Crime Applications Adapter, we need to include the meansReviewType & passportReviewType field from the means_test in the API response. Added the review type field in the response



## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.