### PR TITLE
LASB-3908 [CAA & MAAT API] Adding field Means & Passport Work Reasons of the means_test to the API result

### DIFF
--- a/crime-applications-adaptor/application/build.gradle
+++ b/crime-applications-adaptor/application/build.gradle
@@ -24,7 +24,7 @@ def versions = [
         resilience4jVersion    : "2.2.0",
         commonsioVersion       : '2.11.0',
         sentryVersion          : "7.11.0",
-        commonsVersion         : "1.9.0",
+        commonsVersion         : "1.10.0",
         tomcatEmbedCoreVersion : "10.1.34",
 ]
 

--- a/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapper.java
+++ b/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapper.java
@@ -53,6 +53,7 @@ public class CrimeApplicationResultMapper {
     crimeApplicationResult.setDateMeansCreated(repOrderState.getDateMeansCreated());
     crimeApplicationResult.setMeansAssessorName(repOrderState.getMeansAssessorName());
     crimeApplicationResult.setMeansReviewType(repOrderState.getMeansReviewType());
+    crimeApplicationResult.setMeansWorkReason(repOrderState.getMeansWorkReason());
   }
 
   private void mapPassportAssessments(
@@ -63,6 +64,7 @@ public class CrimeApplicationResultMapper {
       crimeApplicationResult.setDatePassportCreated(repOrderState.getDatePassportCreated());
       crimeApplicationResult.setPassportAssessorName(repOrderState.getPassportAssessorName());
       crimeApplicationResult.setPassportReviewType(repOrderState.getPassportReviewType());
+      crimeApplicationResult.setPassportWorkReason(repOrderState.getPassportWorkReason());
     }
   }
 

--- a/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/model/RepOrderState.java
+++ b/crime-applications-adaptor/application/src/main/java/uk/gov/justice/laa/crime/applications/adaptor/model/RepOrderState.java
@@ -46,4 +46,6 @@ public class RepOrderState {
 
   private String meansReviewType;
   private String passportReviewType;
+  private String meansWorkReason;
+  private String passportWorkReason;
 }

--- a/crime-applications-adaptor/application/src/test/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapperTest.java
+++ b/crime-applications-adaptor/application/src/test/java/uk/gov/justice/laa/crime/applications/adaptor/mapper/crimeapply/CrimeApplicationResultMapperTest.java
@@ -126,6 +126,8 @@ class CrimeApplicationResultMapperTest {
         .ccRepDecision("Granted - Passed Means Test")
         .meansReviewType("NAFI")
         .passportReviewType("ER")
+        .meansWorkReason("PAI")
+        .passportWorkReason("FMA")
         .build();
   }
 
@@ -153,6 +155,8 @@ class CrimeApplicationResultMapperTest {
     result.setCcRepDecision("Granted - Passed Means Test");
     result.setMeansReviewType("NAFI");
     result.setPassportReviewType("ER");
+    result.setMeansWorkReason("PAI");
+    result.setPassportWorkReason("FMA");
     return result;
   }
 
@@ -179,6 +183,8 @@ class CrimeApplicationResultMapperTest {
         .ccRepDecision(null)
         .meansReviewType(null)
         .passportReviewType(null)
+        .meansWorkReason(null)
+        .passportWorkReason(null)
         .build();
   }
 
@@ -203,6 +209,8 @@ class CrimeApplicationResultMapperTest {
     result.setCcRepDecision(null);
     result.setPassportReviewType(null);
     result.setMeansReviewType(null);
+    result.setMeansWorkReason(null);
+    result.setPassportWorkReason(null);
     return result;
   }
 }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-3908)

Describe what you did and why.

As part of the enhancement to the LAA Crime Applications Adapter, we need to include the Work Reason Code field from the means_test in the API response. Added the meansWorkReason & passportWorkReason field in the response

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.