### PR TITLE
Fix security vulnerability in spring-security-crypto

### DIFF
--- a/crime-applications-adaptor/application/build.gradle
+++ b/crime-applications-adaptor/application/build.gradle
@@ -26,6 +26,8 @@ def versions = [
         sentryVersion          : "7.11.0",
         commonsVersion         : "1.10.0",
         tomcatEmbedCoreVersion : "10.1.34",
+        oauth2ResourceServer   : "3.4.1",
+        securityCrypto         : "6.4.4"
 ]
 
 
@@ -42,8 +44,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-webflux"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-aop"
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:$versions.oauth2ResourceServer"
     implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
+    implementation "org.springframework.security:spring-security-crypto:$versions.securityCrypto"
 
     implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:$versions.springdocVersion"
     implementation "org.apache.commons:commons-lang3:$versions.commonsLang3Version"


### PR DESCRIPTION
This PR fixes the [recently published security vulnerability] (https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) in `spring-security-crypto` by forcibly bumping the dependency up to version `6.4.4`.

Spring Boot version `3.4.4` does patch `spring-security-crypto` to this same version, but in order to upgrade Spring Boot, Crime Commons modules also need to be upgraded at the same time, which has more potential to cause problems elsewhere. In that context and to ensure that the Orchestration Service can be as quickly fixed to allow deployments once again, this temporary fix is made in this PR until such time as Spring Boot is upgraded to `3.4.4`.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1788)
